### PR TITLE
find with path argument, xargs -i is deprecated, use -I

### DIFF
--- a/ccache-install.sh
+++ b/ccache-install.sh
@@ -2,4 +2,4 @@
 
 cd root/bin
 mkdir -p ../ccache
-find -type f | xargs -i{} ln -sf ../../../ccache.sh ../ccache/{}
+find ./ -type f | xargs -I{} ln -sf ../../../ccache.sh ../ccache/{}


### PR DESCRIPTION
Hi.

I needed to make those changes in order for the build-scripts to work on osx (10.9.5)

from http://unixhelp.ed.ac.uk/CGI/man-cgi?xargs
"The -l and -i options appear in the 1997 version of the POSIX standard, but  do    not appear in the 2004 version of the standard. Therefore you should use -L and -I instead, respectively."

So it should be fine to use xargs -I
afaik the changes should not affect the behaviour on linux
