### PR TITLE
passing arguments to build-gcc

### DIFF
--- a/build-gcc-elf.sh
+++ b/build-gcc-elf.sh
@@ -1,3 +1,3 @@
 #! /bin/bash -ex
 
-VARIANT=$1 SUFFIX=elf `dirname "$0"`/build-gcc.sh --with-newlib
+VARIANT=$1 SUFFIX=elf `dirname "$0"`/build-gcc.sh --with-newlib "${@:2}"


### PR DESCRIPTION
hi.

with this change it was able to pass additional arguments to gccs configure script.
on osx i needed to specify the path for gmp, mpfr and mpc...

i could compile everything in on go with:
./build-elf.sh lx106 --with-mpc=/opt/local --with-mpfr=/opt/local --with-gmp=/opt/local
